### PR TITLE
Pr patch new free polynomail

### DIFF
--- a/drake/common/symbolic_polynomial.cc
+++ b/drake/common/symbolic_polynomial.cc
@@ -180,6 +180,9 @@ Polynomial::Polynomial(const Monomial& m)
   DRAKE_ASSERT(decision_variables().empty());
 }
 
+Polynomial::Polynomial(const MapType& init)
+    : monomial_to_coefficient_map_{init} {};
+
 Polynomial::Polynomial(const Expression& e, const Variables& indeterminates)
     : monomial_to_coefficient_map_{
           DecomposePolynomialVisitor{}.Decompose(e, indeterminates)} {

--- a/drake/common/symbolic_polynomial.h
+++ b/drake/common/symbolic_polynomial.h
@@ -34,6 +34,10 @@ class Polynomial {
   /// in `m` are considered as indeterminates.
   explicit Polynomial(const Monomial& m);
 
+  /// Construct a polynomial from a std::unordered_map<Monomial, Expression,
+  /// hash_value<Monomial>>
+  explicit Polynomial(const MapType& init);
+
   /// Constructs a polynomial from an expression @p e by decomposing it with
   /// respect to @p indeterminates.
   Polynomial(const Expression& e, const Variables& indeterminates);

--- a/drake/common/symbolic_variables.cc
+++ b/drake/common/symbolic_variables.cc
@@ -21,6 +21,12 @@ namespace symbolic {
 
 Variables::Variables(std::initializer_list<value_type> init) : vars_(init) {}
 
+Variables::Variables(MatrixXVariable init) {
+  for (int i = 0; i < init.size(); ++i) {
+    this->insert(init(i));
+  }
+}
+
 size_t Variables::get_hash() const { return hash_value<set>{}(vars_); }
 
 string Variables::to_string() const {

--- a/drake/common/symbolic_variables.h
+++ b/drake/common/symbolic_variables.h
@@ -7,6 +7,8 @@
 #include <set>
 #include <string>
 
+#include <Eigen/Core>
+
 #include "drake/common/symbolic_variable.h"
 
 namespace drake {
@@ -27,6 +29,9 @@ class Variables {
 
   typedef typename drake::symbolic::Variable key_type;
   typedef typename drake::symbolic::Variable value_type;
+  typedef
+      typename Eigen::Matrix<symbolic::Variable, Eigen::Dynamic, Eigen::Dynamic>
+          MatrixXVariable;
   typedef typename std::set<key_type> set;
   typedef typename set::size_type size_type;
   typedef typename set::iterator iterator;
@@ -39,6 +44,9 @@ class Variables {
 
   /** List constructor. */
   Variables(std::initializer_list<value_type> init);
+
+  /** Creator from Eigen::Matrix<symbolic::Variable>.*/
+  Variables(MatrixXVariable init);
 
   /** Returns hash value. */
   size_t get_hash() const;

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -108,6 +108,9 @@ target_link_libraries(symbolic_variable_test drakeCommon)
 drake_add_cc_test(symbolic_variable_overloading_test)
 target_link_libraries(symbolic_variable_overloading_test drakeCommon)
 
+drake_add_cc_test(symbolic_polynomial_test)
+target_link_libraries(symbolic_polynomial_test drakeCommon)
+
 drake_add_cc_test(symbolic_variables_test)
 target_link_libraries(symbolic_variables_test drakeCommon)
 

--- a/drake/common/test/symbolic_polynomial_test.cc
+++ b/drake/common/test/symbolic_polynomial_test.cc
@@ -88,14 +88,23 @@ TEST_F(SymbolicPolynomialTest, ConstructFromExpression) {
 
 TEST_F(SymbolicPolynomialTest, ConstructFromMonomial) {
   for (int i = 0; i < monomials_.size(); ++i) {
-    const Monomial& x{monomials_[i]};
-    const Polynomial p{x};
+    const Polynomial p{monomials_[i]};
     for (const std::pair<Monomial, Expression>& map :
          p.monomial_to_coefficient_map()) {
-      EXPECT_EQ(map.first, x);
+      EXPECT_EQ(map.first, monomials_[i]);
       EXPECT_EQ(map.second, 1);
     }
   }
+}
+
+TEST_F(SymbolicPolynomialTest, ConstructFromMapType) {
+  Polynomial::MapType p_map;
+  for (int i = 0; i < monomials_.size(); ++i) {
+    p_map.emplace(monomials_[i], 1);
+  }
+  Polynomial p{p_map};
+
+  EXPECT_EQ(p.monomial_to_coefficient_map(), p_map);
 }
 
 TEST_F(SymbolicPolynomialTest, ConstructFromExpressionWithIndeterminates) {

--- a/drake/common/test/symbolic_variables_test.cc
+++ b/drake/common/test/symbolic_variables_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/symbolic_variables.h"
 
+#include <Eigen/Core>
 #include <gtest/gtest.h>
 
 #include "drake/common/symbolic_variable.h"
@@ -17,6 +18,22 @@ class VariablesTest : public ::testing::Test {
   const Variable w_{"w"};
   const Variable v_{"v"};
 };
+
+TEST_F(VariablesTest, ConversionFunction) {
+  const Eigen::Matrix<symbolic::Variable, 3, 1> A1(x_, y_, z_);
+  const Variables vars1(A1);
+  EXPECT_EQ(vars1.size(), 3u);
+  EXPECT_TRUE(vars1.include(x_));
+  EXPECT_TRUE(vars1.include(y_));
+  EXPECT_TRUE(vars1.include(z_));
+
+  const Eigen::Matrix<symbolic::Variable, 3, 1> A2(x_, x_, y_);
+  const Variables vars2(A2);
+  EXPECT_EQ(vars2.size(), 2u);
+  EXPECT_TRUE(vars2.include(x_));
+  EXPECT_TRUE(vars2.include(y_));
+  EXPECT_FALSE(vars2.include(z_));
+}
 
 TEST_F(VariablesTest, HashEq) {
   const Variables vars1{x_, y_, z_};

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -208,18 +208,19 @@ VectorXDecisionVariable MathematicalProgram::NewBinaryVariables(
   return NewVariables(VarType::BINARY, rows, names);
 }
 
-drake::symbolic::Polynomial MathematicalProgram::NewFreePolynomial(
+symbolic::Polynomial MathematicalProgram::NewFreePolynomial(
     const Variables& indeterminates, const int degree) {
-  const drake::VectorX<symbolic::Monomial> x{
+  const drake::VectorX<symbolic::Monomial> m{
       MonomialBasis(indeterminates, degree)};
-  const VectorXDecisionVariable coeffs{NewContinuousVariables(x.size())};
+  const VectorXDecisionVariable coeffs{NewContinuousVariables(m.size())};
 
   // TODO(soonho): make coeffs.dot(X) work.
-  symbolic::Polynomial p;
-  for (int i = 0; i < x.size(); ++i) {
-    p += x(i) * coeffs(i);
+  symbolic::Polynomial::MapType p_map;
+  for (int i = 0; i < m.size(); ++i) {
+    p_map.emplace(m(i), coeffs(i));
   }
-  return p;
+
+  return symbolic::Polynomial{p_map};;
 }
 
 pair<symbolic::Polynomial, Binding<PositiveSemidefiniteConstraint>>


### PR DESCRIPTION
This PR patches the problem inside `MathematicalProgram::NewFreePolynomial` which returns a polynomial `symbolic::Polynomial p{expression}`. This does not account for the existence of `decision_variables`. The patched version creates a new `symbolic::Polynomial` with an initializing `symbolic::Polynomial::MapType`. 

- adds conversion function (constructor) `Polynomial(MapType)`
- adds unit tests for the conversion
- patches the described problem in `NewFreePolynomial`
- adds unit tests for `NewFreePolynomial`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soonho-tri/drake/23)
<!-- Reviewable:end -->
